### PR TITLE
Build spendings page

### DIFF
--- a/client/src/components/FilterForm.js
+++ b/client/src/components/FilterForm.js
@@ -8,12 +8,19 @@ import SelectField from './SelectField.js';
 import SubmitButton from './SubmitButton';
 
 const Container = styled.div`
-  padding: 20px;
-  margin-bottom: 80px;
+  padding: 20px 5px 20px 5px;
+  margin-bottom: 200px;
+  position: absolute;
+  top: 10px;
+  right: 1px;
+  left: 1px;
+  z-index: 999;
+  margin: 20px;
 `;
 
 const FormElement = styled.form`
   width: 100%;
+  height: 300px;
   box-shadow: 0px 3px 20px #00000029;
   background-color: ${light.colors.basic};
   padding: 20px 30px 20px 30px;
@@ -50,6 +57,8 @@ const Headings = styled.p`
   all: unset;
   margin-right: auto;
   font-size: 14px;
+  margin-top: 10px;
+  margin-bottom: 3px;
 `;
 
 export default function FilterForm() {

--- a/client/src/components/FilterForm.js
+++ b/client/src/components/FilterForm.js
@@ -10,12 +10,15 @@ import SubmitButton from './SubmitButton';
 const Container = styled.div`
   padding: 20px 5px 20px 5px;
   margin-bottom: 200px;
-  position: absolute;
-  top: 10px;
-  right: 1px;
-  left: 1px;
+  position: fixed;
+  top: 0;
+  left: 0;
   z-index: 999;
-  margin: 20px;
+  display: flex;
+  align-items: center;
+  width: 100vw;
+  height: 100vh;
+  backdrop-filter: blur(5px);
 `;
 
 const FormElement = styled.form`
@@ -44,6 +47,7 @@ const Container1 = styled.div`
 const Container2 = styled.div`
   display: flex;
   justify-content: center;
+  width: 100%;
 `;
 
 const Container3 = styled.div`
@@ -61,23 +65,34 @@ const Headings = styled.p`
   margin-bottom: 3px;
 `;
 
-export default function FilterForm() {
+const styleFirstInput = {
+  marginLeft: 0
+};
+
+const styleSecondInput = {
+  marginRight: 0
+};
+
+export default function FilterForm({ handleClick, handleClose }) {
+  function stop(event) {
+    event.stopPropagation();
+  }
   return (
-    <Container>
-      <FormElement>
+    <Container onClick={handleClose}>
+      <FormElement onClick={stop}>
         <Container1>
           <Title>Filter einstellen</Title>
-          <CloseIcon></CloseIcon>
+          <CloseIcon onClick={handleClose}></CloseIcon>
         </Container1>
         <Container3>
           <Headings>Datum</Headings>
           <Container2>
-            <InputFieldSmall type="date"></InputFieldSmall>
-            <InputFieldSmall type="date"></InputFieldSmall>
+            <InputFieldSmall style={styleFirstInput} type="date"></InputFieldSmall>
+            <InputFieldSmall style={styleSecondInput} type="date"></InputFieldSmall>
           </Container2>
           <Headings>Kategorie</Headings>
           <SelectField></SelectField>
-          <SubmitButton>Speichern</SubmitButton>
+          <SubmitButton onClick={handleClick}>Speichern</SubmitButton>
         </Container3>
       </FormElement>
     </Container>

--- a/client/src/components/InputFieldSmall.js
+++ b/client/src/components/InputFieldSmall.js
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import light from '../themes/light.js';
 
 const InputFieldSmall = styled.input`
-  width: 150px;
+  width: 100%;
   height: 35px;
   background-color: ${light.colors.backgroundprimary};
   border-radius: 10px;

--- a/client/src/components/SelectField.js
+++ b/client/src/components/SelectField.js
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import light from '../themes/light.js';
 
 const Select = styled.select`
-  width: 281px;
+  width: 100%;
   height: 35px;
   background-color: ${light.colors.backgroundprimary};
   border-radius: 10px;

--- a/client/src/components/SelectField.js
+++ b/client/src/components/SelectField.js
@@ -19,7 +19,7 @@ const Select = styled.select`
 
 export default function SelectField() {
   return (
-    <Select class="ui dropdown">
+    <Select className="ui dropdown">
       <option>Essen</option>
       <option>Transport</option>
       <option>Flüge</option>

--- a/client/src/components/SpendingCard.js
+++ b/client/src/components/SpendingCard.js
@@ -11,7 +11,7 @@ const SpendingCardElement = styled.div`
   justify-content: space-around;
   align-items: center;
   background-color: ${light.colors.basic};
-  margin: 30px 20px 10px 20px;
+  margin: 10px 20px 10px 20px;
 `;
 
 const Wrapper = styled.div`

--- a/client/src/components/SpendingCard.js
+++ b/client/src/components/SpendingCard.js
@@ -3,11 +3,6 @@ import styled from '@emotion/styled';
 import light from '../themes/light.js';
 import FoodIcon from './icons/food';
 
-const Container = styled.div`
-  height: 200px;
-  padding: 20px;
-`;
-
 const SpendingCardElement = styled.div`
   height: 60px;
   box-shadow: 0pt 3pt 20pt #00000029;
@@ -16,6 +11,7 @@ const SpendingCardElement = styled.div`
   justify-content: space-around;
   align-items: center;
   background-color: ${light.colors.basic};
+  margin: 30px 20px 10px 20px;
 `;
 
 const Wrapper = styled.div`
@@ -50,19 +46,17 @@ const Wrapper2 = styled.div`
 
 export default function SpendingCard() {
   return (
-    <Container>
-      <SpendingCardElement>
-        <Wrapper2>
-          <div>
-            <FoodIcon />
-          </div>
-          <Wrapper>
-            <Title>Oma Jamu</Title>
-            <Location>Canggu, Bali</Location>
-          </Wrapper>
-        </Wrapper2>
-        <Spending>-50.000 IDR</Spending>
-      </SpendingCardElement>
-    </Container>
+    <SpendingCardElement>
+      <Wrapper2>
+        <div>
+          <FoodIcon />
+        </div>
+        <Wrapper>
+          <Title>Oma Jamu</Title>
+          <Location>Canggu, Bali</Location>
+        </Wrapper>
+      </Wrapper2>
+      <Spending>-50.000 IDR</Spending>
+    </SpendingCardElement>
   );
 }

--- a/client/src/components/SubmitButton.js
+++ b/client/src/components/SubmitButton.js
@@ -11,6 +11,7 @@ const SubmitButton = styled.button`
   outline: none;
   border: none;
   font-size: 12px;
+  margin-top: 10px;
 `;
 
 export default SubmitButton;

--- a/client/src/components/icons/check.svg
+++ b/client/src/components/icons/check.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>

--- a/client/src/components/icons/drinks.js
+++ b/client/src/components/icons/drinks.js
@@ -11,7 +11,7 @@ const Svg = styled.svg`
 
 export default function DrinkIcon(props) {
   return (
-    <Svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <Svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" {...props}>
       <path d="M21 5V3H3v2l8 9v5H6v2h12v-2h-5v-5l8-9zM7.43 7L5.66 5h12.69l-1.78 2H7.43z" />
       <path fill="none" d="M0 0h24v24H0z" />
     </Svg>

--- a/client/src/components/icons/filter.js
+++ b/client/src/components/icons/filter.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import light from '../../themes/light.js';
+
+const Svg = styled.svg`
+  fill: ${light.colors.action};
+  width: 25px;
+  height: 25px;
+`;
+
+export default function FilterIcon(props) {
+  return (
+    <Svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" {...props}>
+      <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z" />
+      <path d="M0 0h24v24H0z" fill="none" />
+    </Svg>
+  );
+}

--- a/client/src/pages/SpendingList.js
+++ b/client/src/pages/SpendingList.js
@@ -1,9 +1,116 @@
 import React from 'react';
+import WaveIcon from '../components/assets/wave.js';
+import styled from '@emotion/styled';
+import NavBarFooter from '../components/NavBarFooter.js';
+import FilterIcon from '../components/icons/filter.js';
+import SpendingCard from '../components/SpendingCard.js';
+import FilterForm from '../components/FilterForm.js';
+import { useState } from 'react';
+
+const SpendingsBackground = styled.header`
+  background-color: ${props => props.theme.colors.background};
+  height: 35%;
+  width: 100%;
+  position: fixed;
+  top: 0;
+`;
+const StyleWaveIcon = {
+  position: 'absolute',
+  bottom: '0'
+};
+
+const HeadingContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Heading = styled.h1`
+  margin: 40px 0px 0px 30px;
+  color: ${props => props.theme.colors.fontprimary};
+`;
+
+const SubHeading = styled.h5`
+  margin: 10px 0px 10px 30px;
+  color: ${props => props.theme.colors.fontprimary};
+`;
+
+const Destination = styled.p`
+  color: ${props => props.theme.colors.fontprimary};
+  margin: 40px 0px 0px 30px;
+`;
+
+const ContentContainer = styled.div`
+  width: 100%;
+  height: 65%;
+  position: fixed;
+  bottom: 0;
+  /* position: fixed;
+  bottom: 0;
+  overflow: auto; */
+`;
+
+const TitleContainer = styled.div`
+  display: flex;
+`;
+
+const ContentTitle = styled.h5`
+  font-size: 14px;
+  color: ${props => props.theme.colors.fontcolor};
+  margin: 30px 0px 0px 30px;
+`;
+
+const StyleIcon = {
+  margin: '30px 0px 0px 200px'
+};
+
+const Date = styled.p`
+  font-size: 14px;
+  margin-left: 30px;
+  color: ${props => props.theme.colors.fontcolor};
+`;
+
+const Container = styled.div`
+  overflow: auto;
+`;
+
+const FilterButton = styled.button`
+  outline: none;
+  border: none;
+  background-color: transparent;
+  width: 30px;
+  height: 30px;
+`;
 
 export default function SpendingList() {
+  const [showFilter, setShowFilter] = useState(false);
   return (
     <>
-      <div>See spendings here</div>
+      <Container>
+        <SpendingsBackground>
+          <Destination>Südostasien</Destination>
+          <HeadingContainer>
+            <Heading>1980 €</Heading>
+            <SubHeading>Verfügbar</SubHeading>
+          </HeadingContainer>
+          <WaveIcon style={StyleWaveIcon} />
+        </SpendingsBackground>
+        <ContentContainer>
+          <TitleContainer>
+            <ContentTitle>Ausgaben</ContentTitle>
+            <FilterButton onClick={() => setShowFilter(!showFilter)}>
+              <FilterIcon style={StyleIcon} />
+            </FilterButton>
+            {showFilter && <FilterForm />}
+          </TitleContainer>
+          <Date>Heute</Date>
+          <SpendingCard />
+          <SpendingCard />
+          <SpendingCard />
+          <SpendingCard />
+          <SpendingCard />
+        </ContentContainer>
+      </Container>
+      <NavBarFooter></NavBarFooter>
     </>
   );
 }

--- a/client/src/pages/SpendingList.js
+++ b/client/src/pages/SpendingList.js
@@ -8,11 +8,9 @@ import FilterForm from '../components/FilterForm.js';
 import { useState } from 'react';
 
 const SpendingsBackground = styled.header`
-  background-color: ${props => props.theme.colors.background};
-  height: 35%;
   width: 100%;
-  position: fixed;
-  top: 0;
+  padding-bottom: 6rem;
+  position: relative;
 `;
 const StyleWaveIcon = {
   position: 'absolute',
@@ -41,12 +39,8 @@ const Destination = styled.p`
 
 const ContentContainer = styled.div`
   width: 100%;
-  height: 65%;
-  position: fixed;
-  bottom: 0;
-  /* position: fixed;
-  bottom: 0;
-  overflow: auto; */
+  background-color: ${props => props.theme.colors.backgroundprimary};
+  padding-bottom: 6rem;
 `;
 
 const TitleContainer = styled.div`
@@ -67,9 +61,11 @@ const Date = styled.p`
   font-size: 14px;
   margin-left: 30px;
   color: ${props => props.theme.colors.fontcolor};
+  margin-bottom: 5px;
 `;
 
 const Container = styled.div`
+  background-color: ${props => props.theme.colors.background};
   overflow: auto;
 `;
 
@@ -83,6 +79,21 @@ const FilterButton = styled.button`
 
 export default function SpendingList() {
   const [showFilter, setShowFilter] = useState(false);
+  function handleFilter(event) {
+    event.preventDefault();
+    console.log(event);
+  }
+  function closeFilter(event) {
+    setShowFilter(false);
+  }
+  const FilterFormFn = ({ showFilter }) => {
+    if (!showFilter) {
+      return null;
+    }
+
+    return <FilterForm handleClick={handleFilter} handleClose={closeFilter} />;
+  };
+
   return (
     <>
       <Container>
@@ -97,10 +108,9 @@ export default function SpendingList() {
         <ContentContainer>
           <TitleContainer>
             <ContentTitle>Ausgaben</ContentTitle>
-            <FilterButton onClick={() => setShowFilter(!showFilter)}>
+            <FilterButton onClick={() => setShowFilter(true)}>
               <FilterIcon style={StyleIcon} />
             </FilterButton>
-            {showFilter && <FilterForm />}
           </TitleContainer>
           <Date>Heute</Date>
           <SpendingCard />
@@ -109,8 +119,9 @@ export default function SpendingList() {
           <SpendingCard />
           <SpendingCard />
         </ContentContainer>
+        <FilterFormFn showFilter={showFilter} />
+        <NavBarFooter></NavBarFooter>
       </Container>
-      <NavBarFooter></NavBarFooter>
     </>
   );
 }

--- a/client/src/themes/light.js
+++ b/client/src/themes/light.js
@@ -7,7 +7,8 @@ const light = {
     fontsmall: '#00161A5F',
     backgroundprimary: '#EFF8F9',
     basic: '#FFFFFF',
-    background: '#91D5E2'
+    background: '#91D5E2',
+    fontcolor: '#0A363E'
   }
 };
 


### PR DESCRIPTION
With this PR the basic structure of the spending page is ready to use. The users sees the current available budget and the spending cards. By clicking the filter icon, a modal pops up, background blurs and user sees the available filters. By clicking the blurred background or the close icon, the pop-up closes.

<img width="405" alt="Bildschirmfoto 2020-01-02 um 13 31 32" src="https://user-images.githubusercontent.com/56833809/71667197-4ec90d80-2d64-11ea-8178-035e4746c3bf.png">

<img width="447" alt="Bildschirmfoto 2020-01-02 um 13 31 40" src="https://user-images.githubusercontent.com/56833809/71667204-52f52b00-2d64-11ea-808f-8a6e23644747.png">
